### PR TITLE
Fix ignore pattern line continuations

### DIFF
--- a/autoload/neomru.vim
+++ b/autoload/neomru.vim
@@ -66,9 +66,9 @@ call neomru#set_default(
       \ 1000, 'g:unite_source_file_mru_limit')
 call neomru#set_default(
       \ 'g:neomru#file_mru_ignore_pattern',
-      \'\~$\|\.\%(o\|exe\|dll\|bak\|zwc\|pyc\|sw[po]\)$'
-      \'\|\%(^\|/\)\.\%(hg\|git\|bzr\|svn\)\%($\|/\)'
-      \'\|^\%(\\\\\|/mnt/\|/media/\|/temp/\|/tmp/\|\%(/private\)\=/var/folders/\)'
+      \'\~$\|\.\%(o\|exe\|dll\|bak\|zwc\|pyc\|sw[po]\)$'.
+      \'\|\%(^\|/\)\.\%(hg\|git\|bzr\|svn\)\%($\|/\)'.
+      \'\|^\%(\\\\\|/mnt/\|/media/\|/temp/\|/tmp/\|\%(/private\)\=/var/folders/\)'.
       \'\|\%(^\%(fugitive\)://\)'
       \, 'g:unite_source_file_mru_ignore_pattern')
 
@@ -81,7 +81,7 @@ call neomru#set_default(
       \ 1000, 'g:unite_source_directory_mru_limit')
 call neomru#set_default(
       \ 'g:neomru#directory_mru_ignore_pattern',
-      \'\%(^\|/\)\.\%(hg\|git\|bzr\|svn\)\%($\|/\)'
+      \'\%(^\|/\)\.\%(hg\|git\|bzr\|svn\)\%($\|/\)'.
       \'\|^\%(\\\\\|/mnt/\|/media/\|/temp/\|/tmp/\|\%(/private\)\=/var/folders/\)',
       \ 'g:unite_source_directory_mru_ignore_pattern')
 "}}}


### PR DESCRIPTION
The line continuations without a `.` to append strings had the effect of adding a single quote after the `$` in the pattern, which never matches.
