### PR TITLE
Highlight path head and tail differently.

### DIFF
--- a/autoload/unite/sources/neomru.vim
+++ b/autoload/unite/sources/neomru.vim
@@ -60,6 +60,12 @@ function! s:file_mru_source.hooks.on_syntax(args, context) "{{{
   syntax match uniteSource__FileMru_Time
         \ /([^)]*)\s\+/
         \ contained containedin=uniteSource__FileMru
+  syntax match uniteSource__FileMru_Directory
+        \ /^.*\//
+  syntax match uniteSource__FileMru_Filename
+        \ /\/\@<=.*$/ 
+  highlight link uniteSource__FileMru_Directory Delimiter
+  highlight link uniteSource__FileMru_Filename Normal
   highlight default link uniteSource__FileMru_Time Statement
 endfunction"}}}
 function! s:dir_mru_source.hooks.on_syntax(args, context) "{{{


### PR DESCRIPTION
I'm not sure this is the right way to do this, so what I really wanted was some comments. Can the source hooks be overriden? I couldn't find info about this in the documentation.

IMHO, this change might help find files visually in the MRU list. See, for example,
![captura de pantalla de 2014-07-13 15 46 55](https://cloud.githubusercontent.com/assets/221465/3565657/4553ad48-0ac7-11e4-84f4-922a696cb811.png)
