### PR TITLE
Add nvim-terminal to file ignore pattern

### DIFF
--- a/autoload/neomru.vim
+++ b/autoload/neomru.vim
@@ -71,7 +71,8 @@ call neomru#set_default(
       \'\~$\|\.\%(o\|exe\|dll\|bak\|zwc\|pyc\|sw[po]\)$'.
       \'\|\%(^\|/\)\.\%(hg\|git\|bzr\|svn\)\%($\|/\)'.
       \'\|^\%(\\\\\|/mnt/\|/media/\|/temp/\|/tmp/\|\%(/private\)\=/var/folders/\)'.
-      \'\|\%(^\%(fugitive\)://\)'
+      \'\|\%(^\%(fugitive\)://\)'.
+      \'\|\%(^\%(term\)://\)'
       \, 'g:unite_source_file_mru_ignore_pattern')
 
 call neomru#set_default(


### PR DESCRIPTION
It should prevent `term://*` (e.g. `:e term://bash`) from saving to mru list.