### PR TITLE
Use symlink (not resolved) path in sources by default

### DIFF
--- a/autoload/neomru.vim
+++ b/autoload/neomru.vim
@@ -86,7 +86,7 @@ call neomru#set_default(
       \'\%(^\|/\)\.\%(hg\|git\|bzr\|svn\)\%($\|/\)'.
       \'\|^\%(\\\\\|/mnt/\|/media/\|/temp/\|/tmp/\|\%(/private\)\=/var/folders/\)',
       \ 'g:unite_source_directory_mru_ignore_pattern')
-call neomru#set_default('g:neomru#follow_symlinks', 0)
+call neomru#set_default('g:neomru#follow_links', 0)
 "}}}
 
 " MRUs  "{{{
@@ -261,7 +261,7 @@ function! s:mru.version_check(ver)  "{{{
 endfunction"}}}
 
 function! s:resolve(fpath)  "{{{
-  return g:neomru#follow_symlinks ? resolve(a:fpath) : a:fpath
+  return g:neomru#follow_links ? resolve(a:fpath) : a:fpath
 endfunction"}}}
 
 "}}}

--- a/autoload/neomru.vim
+++ b/autoload/neomru.vim
@@ -86,6 +86,7 @@ call neomru#set_default(
       \'\%(^\|/\)\.\%(hg\|git\|bzr\|svn\)\%($\|/\)'.
       \'\|^\%(\\\\\|/mnt/\|/media/\|/temp/\|/tmp/\|\%(/private\)\=/var/folders/\)',
       \ 'g:unite_source_directory_mru_ignore_pattern')
+call neomru#set_default('g:neomru#follow_symlinks', 0)
 "}}}
 
 " MRUs  "{{{
@@ -259,6 +260,10 @@ function! s:mru.version_check(ver)  "{{{
   endif
 endfunction"}}}
 
+function! s:resolve(fpath)  "{{{
+  return g:neomru#follow_symlinks ? resolve(a:fpath) : a:fpath
+endfunction"}}}
+
 "}}}
 
 " File MRU:   "{{{2
@@ -334,7 +339,7 @@ function! neomru#_append() "{{{
   let path = s:substitute_path_separator(expand('%:p'))
   if path !~ '\a\+:'
     let path = s:substitute_path_separator(
-          \ simplify(resolve(path)))
+          \ simplify(s:resolve(path)))
   endif
 
   " Append the current buffer to the mru list.
@@ -353,7 +358,7 @@ function! neomru#_append() "{{{
     let path = getcwd()
   endif
 
-  let path = s:substitute_path_separator(simplify(resolve(path)))
+  let path = s:substitute_path_separator(simplify(s:resolve(path)))
   " Chomp last /.
   let path = substitute(path, '/$', '', '')
 

--- a/doc/neomru.txt
+++ b/doc/neomru.txt
@@ -150,6 +150,15 @@ g:neomru#directory_mru_ignore_pattern
 		Note: It is deprecated name.
 
 		The targets are directory mru.
+							*g:neomru#follow_links*
+g:neomru#follow_links
+		A boolean which determines whether symbolic or hard-linked
+		files should be followed (resolved): if false, symlinked
+		files and directories are listed in the unite buffer using the
+		symlink's path; if true, they are listed using the real path.
+
+		The default value is 0 (false).
+
 
 ------------------------------------------------------------------------------
 SOURCES						*neomru-sources*


### PR DESCRIPTION
if I have a symlink from "/path/to/somewhere/foo.txt" to "~/bar.txt", and I edit "~/bar.txt" in vim, I expect to see "bar.txt" in my mru files and be able to filter against it, rather than "foo.txt". 

It's configurable via a global variable, `neormu#follow_links`, and I've changed the default behaviour as above.