### PR TITLE
Allow for relative paths in abbr

### DIFF
--- a/autoload/neomru.vim
+++ b/autoload/neomru.vim
@@ -359,10 +359,9 @@ function! neomru#_save(...) abort "{{{
     call m.save(opts)
   endfor
 endfunction"}}}
-function! neomru#_abbr(path) abort "{{{
+function! neomru#_abbr(path, time) abort "{{{
   let abbr = (g:neomru#time_format == '') ? '' :
-          \ strftime('(' . g:neomru#time_format . ') ',
-          \          getftime(expand(a:path)))
+          \ strftime('(' . g:neomru#time_format . ') ', a:time)
   let abbr .= a:path
   return abbr
 endfunction"}}}

--- a/autoload/unite/sources/neomru.vim
+++ b/autoload/unite/sources/neomru.vim
@@ -122,7 +122,7 @@ function! s:converter(candidates, context) abort "{{{
     endif
 
     " Set default abbr.
-    let candidate.abbr = neomru#_abbr(path)
+    let candidate.abbr = neomru#_abbr(path, getftime(candidate.action__path))
   endfor
 
   return a:candidates

--- a/doc/neomru.txt
+++ b/doc/neomru.txt
@@ -157,6 +157,12 @@ file_mru
 		Set a large number like 5000 for the long limit will not
 		impact vim performance.
 
+		Source custom variables:
+		fnamemodify
+			a flag to modify given paths.
+			Use |filename-modifiers|.
+				(default is ':~')
+
 						*unite-source-neomru/directory*
 neomru/directory
 						*unite-source-directory_mru*

--- a/rplugin/python3/denite/source/file_mru.py
+++ b/rplugin/python3/denite/source/file_mru.py
@@ -5,7 +5,6 @@
 # ============================================================================
 
 from .base import Base
-from denite.util import relpath
 
 
 class Source(Base):
@@ -16,12 +15,22 @@ class Source(Base):
         self.name = 'file_mru'
         self.kind = 'file'
         self.sorters = []
+        self.vars = {
+            'fnamemodify': ':~',
+        }
 
     def gather_candidates(self, context):
+        def time_format(x):
+            return self.vim.call('getftime', x)
+
+        def path_format(x):
+            return self.vim.call('fnamemodify', x, self.vars['fnamemodify'])
+
         return [{
-            'word': x,
-            'abbr': self.vim.call('neomru#_abbr', relpath(self.vim, x)),
+            'word': path_format(x),
+            'abbr': self.vim.call('neomru#_abbr',
+                path_format(x), time_format(x)),
             'action__path': x
         } for x in self.vim.eval(
             'neomru#_get_mrus().file.'
-            +'gather_candidates([], {"is_redraw": 0})')]
+            + 'gather_candidates([], {"is_redraw": 0})')]


### PR DESCRIPTION
This introduces a new setting to `fnamemodify` file locations for
display.

Defaults to the old behaviour of not touching the paths.

This "fixes" my problem with #42 